### PR TITLE
remove 24.10 config

### DIFF
--- a/build_box.sh
+++ b/build_box.sh
@@ -16,7 +16,6 @@ cp -r "${BASE_DIR}/config/" "${GIT_CLONE_DIR}/packer_templates/config"
 
 cd "${GIT_CLONE_DIR}"
 
-cp "${BASE_DIR}/config/ubuntu-24.10-x86_64.pkrvars.hcl" ./os_pkrvars/ubuntu/
 git apply ./packer_templates/config/bento.diff
 
 packer init -upgrade ./packer_templates

--- a/config/ubuntu-24.10-x86_64.pkrvars.hcl
+++ b/config/ubuntu-24.10-x86_64.pkrvars.hcl
@@ -1,9 +1,0 @@
-os_name                 = "ubuntu"
-os_version              = "24.10"
-os_arch                 = "x86_64"
-iso_url                 = "https://releases.ubuntu.com/oracular/ubuntu-24.10-live-server-amd64.iso"
-iso_checksum            = "file:https://releases.ubuntu.com/oracular/SHA256SUMS"
-parallels_guest_os_type = "ubuntu"
-vbox_guest_os_type      = "Ubuntu_64"
-vmware_guest_os_type    = "ubuntu-64"
-boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]


### PR DESCRIPTION
no longer required due to https://github.com/chef/bento/pull/1583